### PR TITLE
Adds integration tests for staff view

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,8 +27,10 @@ jobs:
 
       - run:
           name: Run tests
+          environment:
+            CYPRESS_JWT_SECRET: my_secret
           command: |
-            echo "/customer-document-uploads/SENTRY_DSN=my_sentry_dsn\n/common/hackney-jwt-secret=my_secret" >> .env
+            echo -e "/customer-document-uploads/SENTRY_DSN=my_sentry_dsn\n/common/hackney-jwt-secret=my_secret" >> .env
             npm run ci
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,10 +1,15 @@
 version: 2.1
-jobs:
-  build:
+
+executors:
+  node:
     docker:
       - image: circleci/node:12.13
 
     working_directory: ~/repo
+
+jobs:
+  build:
+    executor: node
 
     steps:
       - checkout
@@ -32,17 +37,29 @@ jobs:
           command: |
             echo -e "/customer-document-uploads/SENTRY_DSN=my_sentry_dsn\n/common/hackney-jwt-secret=my_secret" >> .env
             npm run ci
+  
+  deploy:
+    executor: node
 
+    steps:
       - run:
           name: Set AWS credentials
           command: |
             ./node_modules/serverless/bin/serverless config credentials --provider aws --key ${AWS_ACCESS_KEY_ID} --secret ${AWS_SECRET_ACCESS_KEY} --profile docuploads
 
-      # - save_cache:
-      #     paths:
-      #       - node_modules
-      #     key: v1-dependencies-{{ checksum "package-lock.json" }}
-
       - run:
           name: Deploy application
           command: ./node_modules/serverless/bin/serverless deploy -s production
+
+workflows:
+  version: 2
+  build-and-deploy-when-master:
+    jobs:
+      - build
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - master

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "baseUrl": "http://localhost:3000",
   "chromeWebSecurity": false,
   "video": false
 }

--- a/cypress/integration/customer.spec.js
+++ b/cypress/integration/customer.spec.js
@@ -69,13 +69,13 @@ context('Customer Actions', () => {
 
     context('when the user has a session', () => {
       it('should redirect to their existing dropbox url', () => {
-        cy.visit('http://localhost:3000/');
+        cy.visit('/');
         cy.location()
           .then(loc => {
             return loc.pathname;
           })
           .then(path => {
-            cy.visit('http://localhost:3000/');
+            cy.visit('/');
             cy.location('pathname').should('eq', path);
           });
       });
@@ -84,7 +84,7 @@ context('Customer Actions', () => {
 
   describe('submitting documents', () => {
     beforeEach(() => {
-      cy.visit('http://localhost:3000/');
+      cy.visit('/');
     });
 
     it('should allow a user to upload multiple documents', () => {
@@ -201,7 +201,7 @@ context('Customer Actions', () => {
       });
 
       it('should always navigate to the submitted dropbox', () => {
-        cy.visit('http://localhost:3000/');
+        cy.visit('/');
         cy.location('pathname').should('match', dropboxUrlRegex);
       });
 

--- a/cypress/integration/staff.spec.js
+++ b/cypress/integration/staff.spec.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+context('Staff actions', () => {
+  context('given that the user has a token', () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit('/');
+    });
+
+    it('shows the staff view', () => {
+      cy.get('h2').contains(/customer uploads/i);
+    });
+
+    it('shows a list of customer dropboxes', () => {
+      cy.get('[data-testid=staff-dropboxes-list]')
+        .children()
+        .should('have.length.greaterThan', 1);
+    });
+  });
+});

--- a/cypress/integration/staff.spec.js
+++ b/cypress/integration/staff.spec.js
@@ -1,12 +1,12 @@
 /// <reference types="cypress" />
 
 context('Staff actions', () => {
-  context('given that the user has a token', () => {
-    beforeEach(() => {
-      cy.login();
-      cy.visit('/');
-    });
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/');
+  });
 
+  context('when visiting the service', () => {
     it('shows the staff view', () => {
       cy.get('h2').contains(/customer uploads/i);
     });
@@ -15,6 +15,32 @@ context('Staff actions', () => {
       cy.get('[data-testid=staff-dropboxes-list]')
         .children()
         .should('have.length.greaterThan', 1);
+    });
+  });
+
+  context('when selecting a customer dropbox', () => {
+    it('shows the customer dropbox details', () => {
+      cy.get('[data-testid=staff-dropboxes-list]')
+        .children()
+        .first()
+        .find('[data-testid=dropbox-link]')
+        .click();
+
+      cy.get('[data-testid=dropbox-details]').should('exist');
+    });
+  });
+
+  context('when viewing a customer dropbox', () => {
+    it('can navigate back to the dropboxes list', () => {
+      cy.get('[data-testid=staff-dropboxes-list]')
+        .children()
+        .first()
+        .find('[data-testid=dropbox-link]')
+        .click();
+
+      cy.get('[data-testid=dropbox-list-return-link]').click();
+
+      cy.get('[data-testid=staff-dropboxes-list]').should('exist');
     });
   });
 });

--- a/cypress/integration/staff.spec.js
+++ b/cypress/integration/staff.spec.js
@@ -1,46 +1,59 @@
 /// <reference types="cypress" />
 
 context('Staff actions', () => {
-  beforeEach(() => {
-    cy.login();
-    cy.visit('/');
-  });
-
-  context('when visiting the service', () => {
-    it('shows the staff view', () => {
-      cy.get('h2').contains(/customer uploads/i);
+  context('when not logged in', () => {
+    beforeEach(() => {
+      cy.logout();
     });
 
-    it('shows a list of customer dropboxes', () => {
-      cy.get('[data-testid=staff-dropboxes-list]')
-        .children()
-        .should('have.length.greaterThan', 1);
+    it('redirects to the login page', () => {
+      cy.visit('/dropboxes');
+      cy.location('pathname').should('equal', '/login');
     });
   });
 
-  context('when selecting a customer dropbox', () => {
-    it('shows the customer dropbox details', () => {
-      cy.get('[data-testid=staff-dropboxes-list]')
-        .children()
-        .first()
-        .find('[data-testid=dropbox-link]')
-        .click();
-
-      cy.get('[data-testid=dropbox-details]').should('exist');
+  context('when logged in as a staff member', () => {
+    beforeEach(() => {
+      cy.login();
+      cy.visit('/');
     });
-  });
 
-  context('when viewing a customer dropbox', () => {
-    it('can navigate back to the dropboxes list', () => {
-      cy.get('[data-testid=staff-dropboxes-list]')
-        .children()
-        .first()
-        .find('[data-testid=dropbox-link]')
-        .click();
+    context('when visiting the service', () => {
+      it('shows the staff view', () => {
+        cy.get('h2').contains(/customer uploads/i);
+      });
 
-      cy.get('[data-testid=dropbox-list-return-link]').click();
+      it('shows a list of customer dropboxes', () => {
+        cy.get('[data-testid=staff-dropboxes-list]')
+          .children()
+          .should('have.length.greaterThan', 1);
+      });
+    });
 
-      cy.get('[data-testid=staff-dropboxes-list]').should('exist');
+    context('when selecting a customer dropbox', () => {
+      it('shows the customer dropbox details', () => {
+        cy.get('[data-testid=staff-dropboxes-list]')
+          .children()
+          .first()
+          .find('[data-testid=dropbox-link]')
+          .click();
+
+        cy.get('[data-testid=dropbox-details]').should('exist');
+      });
+    });
+
+    context('when viewing a customer dropbox', () => {
+      it('can navigate back to the dropboxes list', () => {
+        cy.get('[data-testid=staff-dropboxes-list]')
+          .children()
+          .first()
+          .find('[data-testid=dropbox-link]')
+          .click();
+
+        cy.get('[data-testid=dropbox-list-return-link]').click();
+
+        cy.get('[data-testid=staff-dropboxes-list]').should('exist');
+      });
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,4 @@
+
 // ***********************************************
 // This example commands.js shows you how to
 // create various custom commands and overwrite
@@ -23,3 +24,9 @@
 //
 // -- This will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('login', () => {
+  const jwt = require('jsonwebtoken');
+  const token = jwt.sign({ groups: [] }, Cypress.env('JWT_SECRET'), { issuer: 'Hackney' });
+  cy.setCookie('hackneyToken', token, { path: '/' });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -30,3 +30,7 @@ Cypress.Commands.add('login', () => {
   const token = jwt.sign({ groups: [] }, Cypress.env('JWT_SECRET'), { issuer: 'Hackney' });
   cy.setCookie('hackneyToken', token, { path: '/' });
 });
+
+Cypress.Commands.add('logout', () => {
+  cy.clearCookie('hackneyToken');
+});

--- a/templates/readonlyDropbox.hbs
+++ b/templates/readonlyDropbox.hbs
@@ -1,9 +1,9 @@
 {{> header }}
 {{#if isStaff }}
-  <a href="/dropboxes">
+  <a href="/dropboxes" data-testid="dropbox-list-return-link">
     << Back to all dropboxes</a>
 {{/if }}
-<div id="dropboxContents">
+<div id="dropboxContents" data-testid="dropbox-details">
   <strong>Name:</strong>
   <p>{{ dropbox.customerName }}</p>
   <strong>Description:</strong>

--- a/templates/staffDropboxList.hbs
+++ b/templates/staffDropboxList.hbs
@@ -11,7 +11,7 @@
       <th scope="col">Submitted</th>
     </tr>
   </thead>
-  <tbody>
+  <tbody data-testid="staff-dropboxes-list">
     {{#each dropboxes}}
       <tr>
         <td scope="row"><a href="/dropboxes/{{this.dropboxId}}/view">{{this.customerName}}</a></td>

--- a/templates/staffDropboxList.hbs
+++ b/templates/staffDropboxList.hbs
@@ -14,7 +14,11 @@
   <tbody data-testid="staff-dropboxes-list">
     {{#each dropboxes}}
       <tr>
-        <td scope="row"><a href="/dropboxes/{{this.dropboxId}}/view">{{this.customerName}}</a></td>
+        <td scope="row">
+          <a data-testid="dropbox-link" href="/dropboxes/{{this.dropboxId}}/view">
+            {{this.customerName}}
+          </a>
+        </td>
         <td>{{this.count}}</td>
         <td>{{this.description}}</td>
         <td>{{this.customerEmail}}</td>


### PR DESCRIPTION
Adds Cypress tests for the staff view, slightly awkward as we can't easily mock the data per-test since it's all rendered server-side so there may be some dependencies based on the order in which the tests run - shouldn't be a huge problem but maybe something to look at improving in the future.

**Other small things included**
 - For new tests, added [`data-testid` attributes](https://kentcdodds.com/blog/making-your-ui-tests-resilient-to-change) so that the selectors used in the tests aren't overly dependant on the structure of the page.
 - Also added `baseUrl` to the `cypress.json` file to avoid duplicating it a bunch of times within the test files.