### PR TITLE
Fix deploys: Attach workspace for CircleCI deploy job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,9 @@ jobs:
     executor: node
 
     steps:
+      - attach_workspace:
+          at: ~/repo
+
       - run:
           name: Set AWS credentials
           command: |


### PR DESCRIPTION
Deployment is currently failing as it cannot find `node_modules`, hopefully this should fix it.