### PR TITLE
Uses different secrets for customer and staff JWTs

### DIFF
--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -17,7 +17,7 @@ const decodeToken = token => {
   }
 };
 
-const requestAllowed = async (tokenPayload, req) => {
+const requestAllowed = tokenPayload => {
   if (tokenPayload.iss === 'Hackney' && tokenPayload.groups) {
     return true;
   }
@@ -28,5 +28,5 @@ const requestAllowed = async (tokenPayload, req) => {
 module.exports = req => {
   const token = extractTokenFromCookieHeader(req);
   const decodedToken = decodeToken(token);
-  return token && decodedToken && requestAllowed(decodedToken, req);
+  return token && decodedToken && requestAllowed(decodedToken);
 };

--- a/lib/authorize.js
+++ b/lib/authorize.js
@@ -21,6 +21,8 @@ const requestAllowed = async (tokenPayload, req) => {
   if (tokenPayload.iss === 'Hackney' && tokenPayload.groups) {
     return true;
   }
+
+  return false;
 };
 
 module.exports = req => {

--- a/lib/sessions.js
+++ b/lib/sessions.js
@@ -1,4 +1,4 @@
-const jwtSecret = process.env.jwtsecret;
+const jwtSecret = process.env.CUSTOMER_TOKEN_SECRET;
 const jwt = require('jsonwebtoken');
 const cookie = require('cookie');
 

--- a/serverless.yml
+++ b/serverless.yml
@@ -8,7 +8,7 @@ provider:
   region: eu-west-2
   apiGateway:
     binaryMediaTypes:
-      - '*/*'
+      - "*/*"
   iamRoleStatements:
     - Effect: Allow
       Action:
@@ -21,14 +21,16 @@ provider:
         - s3:GetObject
         - s3:DeleteObject
         - s3:ListBucket
-      Resource: '*'
+      Resource: "*"
   environment:
-    DROPBOXES_TABLE: '${self:service}-${self:provider.stage}-dropboxes'
-    UPLOADS_BUCKET: '${self:service}-${self:provider.stage}-uploads'
+    DROPBOXES_TABLE: "${self:service}-${self:provider.stage}-dropboxes"
+    UPLOADS_BUCKET: "${self:service}-${self:provider.stage}-uploads"
     SENTRY_DSN: ${ssm:/customer-document-uploads/SENTRY_DSN}
     URL_PREFIX: ${self:custom.endpoints.${self:provider.stage}}
+    EVIDENCE_STORE_URL: ${self:custom.evidenceStoreUrls.${self:provider.stage}}
     MAX_UPLOAD_BYTES: 20_971_520
     jwtsecret: ${ssm:/common/hackney-jwt-secret}
+    CUSTOMER_TOKEN_SECRET: ${ssm:/common/customer-jwt-secret~true}
     stage: ${self:provider.stage}
 
 custom:
@@ -82,7 +84,7 @@ functions:
         - node_modules/**
     events:
       - http:
-          path: '/dropboxes/{dropboxId}'
+          path: "/dropboxes/{dropboxId}"
           method: POST
   app:
     handler: lambda.handler
@@ -95,7 +97,7 @@ functions:
         - node_modules/**
     events:
       - http:
-          path: '{proxy+}'
+          path: "{proxy+}"
           method: ANY
 
 resources:
@@ -114,7 +116,7 @@ resources:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
     UploadsDynamoDbTable:
-      Type: 'AWS::DynamoDB::Table'
+      Type: "AWS::DynamoDB::Table"
       DeletionPolicy: Retain
       Properties:
         AttributeDefinitions:


### PR DESCRIPTION
Improves security by using different secrets for customer tokens and staff token, ensuring that they cannot be interchanged.