### PR TITLE
Switches to using Evidence Store API

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,13 +39,13 @@ jobs:
           environment:
             CYPRESS_JWT_SECRET: my_secret
           command: |
-            echo -e "/customer-document-uploads/SENTRY_DSN=my_sentry_dsn\n/common/hackney-jwt-secret=my_secret" >> .env
+            echo -e "/customer-document-uploads/SENTRY_DSN=my_sentry_dsn\n/common/hackney-jwt-secret=my_secret\n/common/customer-jwt-secret=my_secret\n/customer-document-uploads/evidence-store-token=${TEST_ES_TOKEN}" >> .env
             npm run ci
 
       - persist_to_workspace:
           root: ~/repo
           paths: .
-  
+
   deploy:
     executor: node
 

--- a/lambda.js
+++ b/lambda.js
@@ -155,7 +155,7 @@ api.post('/dropboxes/:dropboxId/files/:fileId', async (req, res) => {
 
   if (session && session.dropboxId === req.params.dropboxId) {
     if (req.body._method === 'DELETE') {
-      await deleteDocument(req.params.dropboxId, req.params.fileId);
+      await deleteDocument(req.params.fileId);
     }
 
     return res.redirect(`/dropboxes/${req.params.dropboxId}`);

--- a/lambda.js
+++ b/lambda.js
@@ -5,6 +5,7 @@ const {
   createEmptyDropbox,
   deleteDocument,
   getEvidenceStoreUrl,
+  getResolvedDownloadUrl,
   getSession,
   createSessionToken,
   templates,
@@ -145,7 +146,8 @@ api.get('/dropboxes/:dropboxId/files/:fileId', async (req, res) => {
     return res.sendStatus(404);
   }
 
-  res.redirect(file.downloadUrl);
+  const downloadUrl = await getResolvedDownloadUrl(file.downloadUrl);
+  res.redirect(downloadUrl);
 });
 
 api.post('/dropboxes/:dropboxId/files/:fileId', async (req, res) => {

--- a/lambda.js
+++ b/lambda.js
@@ -4,7 +4,7 @@ const {
   getDropboxes,
   createEmptyDropbox,
   deleteDocument,
-  getSecureUploadUrl,
+  getEvidenceStoreUrl,
   getSession,
   createSessionToken,
   templates,
@@ -109,7 +109,7 @@ api.get('/dropboxes/:id', async (req, res) => {
     return res.html(templates.readonlyDropboxTemplate(params));
   }
 
-  const { url, fields, documentId } = await getSecureUploadUrl(dropboxId);
+  const { url, fields, documentId } = await getEvidenceStoreUrl(dropboxId);
 
   res.html(
     templates.createDropboxTemplate({

--- a/lib/Dependencies.js
+++ b/lib/Dependencies.js
@@ -40,6 +40,7 @@ const deleteDocument = require('./use-cases/DeleteDocument')(container);
 const getSecureUploadUrl = require('./use-cases/GetSecureUploadUrl')(container);
 const saveDropbox = require('./use-cases/SaveDropbox')(container);
 const getEvidenceStoreUrl = require('./use-cases/GetEvidenceStoreUrl')(container);
+const getResolvedDownloadUrl = require('./use-cases/GetResolvedDownloadUrl')(container);
 
 module.exports = {
   getDropbox,
@@ -52,6 +53,7 @@ module.exports = {
   createSessionToken,
   getEvidenceStoreUrl,
   getSecureUploadUrl,
+  getResolvedDownloadUrl,
   templates,
   authorize
 };

--- a/lib/Dependencies.js
+++ b/lib/Dependencies.js
@@ -7,9 +7,11 @@ const { getSession, createSessionToken } = require('./sessions');
 const templates = loadTemplates(path.join(__dirname, '../templates'));
 const authorize = require('./authorize');
 const log = require('./log')();
+const EvidenceStoreGateway = require('./gateways/document/EvidenceStoreGateway')
 
 const configuration = {
   urlPrefix: process.env.URL_PREFIX,
+  evidenceStoreUrl: process.env.EVIDENCE_STORE_URL,
   maxUploadBytes: parseInt(process.env.MAX_UPLOAD_BYTES) || 20_971_520
 };
 
@@ -22,6 +24,9 @@ const container = {
       ...s3Config,
       log,
       configuration
+    }),
+    evidenceStore: new EvidenceStoreGateway({
+      baseUrl: configuration.evidenceStoreUrl
     })
   }
 };
@@ -32,6 +37,7 @@ const createEmptyDropbox = require('./use-cases/CreateEmptyDropbox')(container);
 const deleteDocument = require('./use-cases/DeleteDocument')(container);
 const getSecureUploadUrl = require('./use-cases/GetSecureUploadUrl')(container);
 const saveDropbox = require('./use-cases/SaveDropbox')(container);
+const getEvidenceStoreUrl = require('./use-cases/GetEvidenceStoreUrl')(container);
 
 module.exports = {
   getDropbox,
@@ -42,6 +48,7 @@ module.exports = {
   generateRandomString,
   getSession,
   createSessionToken,
+  getEvidenceStoreUrl,
   getSecureUploadUrl,
   templates,
   authorize

--- a/lib/Dependencies.js
+++ b/lib/Dependencies.js
@@ -12,6 +12,7 @@ const EvidenceStoreGateway = require('./gateways/document/EvidenceStoreGateway')
 const configuration = {
   urlPrefix: process.env.URL_PREFIX,
   evidenceStoreUrl: process.env.EVIDENCE_STORE_URL,
+  evidenceStoreToken: process.env.EVIDENCE_STORE_TOKEN,
   maxUploadBytes: parseInt(process.env.MAX_UPLOAD_BYTES) || 20_971_520
 };
 
@@ -27,7 +28,7 @@ const container = {
     }),
     evidenceStore: new EvidenceStoreGateway({
       baseUrl: configuration.evidenceStoreUrl,
-      authorizationToken: process.env.EVIDENCE_STORE_TOKEN
+      authorizationToken: configuration.evidenceStoreToken,
     })
   }
 };

--- a/lib/Dependencies.js
+++ b/lib/Dependencies.js
@@ -26,7 +26,8 @@ const container = {
       configuration
     }),
     evidenceStore: new EvidenceStoreGateway({
-      baseUrl: configuration.evidenceStoreUrl
+      baseUrl: configuration.evidenceStoreUrl,
+      authorizationToken: process.env.EVIDENCE_STORE_TOKEN
     })
   }
 };

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -1,7 +1,9 @@
+const { Document } = require('../../domain/dropbox');
 const fetch = require('node-fetch');
 
 class EvidenceStoreGateway {
   constructor({ baseUrl }) {
+    console.log('url', { baseUrl });
     this.baseUrl = baseUrl;
   }
 
@@ -19,6 +21,30 @@ class EvidenceStoreGateway {
         documentId: data.documentId
       };
     } else {
+      console.log(response);
+      throw new Error('Call to Evidence Store failed.');
+    }
+  }
+
+  async getByDropboxId(dropboxId) {
+    const response = await fetch(`${this.baseUrl}/documents`, {
+      body: JSON.stringify({ dropboxId }),
+      method: 'POST'
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return data.map(
+        result =>
+          new Document({
+            id: result.documentId,
+            filename: result.downloadUrl.split('/').reverse()[0],
+            description: result.description,
+            downloadUrl: result.downloadUrl
+          })
+      );
+    } else {
+      console.log(response);
       throw new Error('Call to Evidence Store failed.');
     }
   }

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -15,7 +15,8 @@ class EvidenceStoreGateway {
       const data = await response.json();
       return {
         url: data.url,
-        fields: data.fields
+        fields: data.fields,
+        documentId: data.documentId
       };
     } else {
       throw new Error('Call to Evidence Store failed.');

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -1,0 +1,26 @@
+const fetch = require('node-fetch');
+
+class EvidenceStoreGateway {
+  constructor({ baseUrl }) {
+    this.baseUrl = baseUrl;
+  }
+
+  async createUploadUrl(dropboxId) {
+    const response = await fetch(`${this.baseUrl}/metadata`, {
+      body: JSON.stringify({ dropboxId }),
+      method: 'POST'
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return {
+        url: data.url,
+        fields: data.fields
+      };
+    } else {
+      throw new Error('Call to Evidence Store failed.');
+    }
+  }
+}
+
+module.exports = EvidenceStoreGateway;

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -7,12 +7,17 @@ class EvidenceStoreGateway {
     this.authorizationToken = authorizationToken;
   }
 
-  buildHeaders() {
-    return {
+  buildHeaders(includeContentType) {
+    const headers = {
       Accept: 'application/json',
-      'Content-Type': 'application/json',
       Authorization: `Bearer ${this.authorizationToken}`
     };
+
+    if (includeContentType !== false) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    return headers;
   }
 
   async createUploadUrl(dropboxId) {
@@ -47,6 +52,18 @@ class EvidenceStoreGateway {
     } else {
       console.log(response);
       throw new Error('Call to Evidence Store failed');
+    }
+  }
+
+  async deleteByDocumentId(documentId) {
+    const response = await fetch(`${this.baseUrl}/${documentId}`, {
+      headers: this.buildHeaders(false),
+      method: 'DELETE'
+    });
+
+    if (!response.ok) {
+      console.log(response);
+      throw new Error('Failed to delete document');
     }
   }
 

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -2,14 +2,23 @@ const { Document } = require('../../domain/dropbox');
 const fetch = require('node-fetch');
 
 class EvidenceStoreGateway {
-  constructor({ baseUrl }) {
-    console.log('url', { baseUrl });
+  constructor({ baseUrl, authorizationToken }) {
     this.baseUrl = baseUrl;
+    this.authorizationToken = authorizationToken;
+  }
+
+  buildHeaders() {
+    return {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.authorizationToken}`
+    };
   }
 
   async createUploadUrl(dropboxId) {
     const response = await fetch(`${this.baseUrl}/metadata`, {
       body: JSON.stringify({ dropboxId }),
+      headers: this.buildHeaders(),
       method: 'POST'
     });
 
@@ -27,19 +36,20 @@ class EvidenceStoreGateway {
   }
 
   async getByDropboxId(dropboxId) {
-    const response = await fetch(`${this.baseUrl}/documents`, {
+    const response = await fetch(`${this.baseUrl}/search`, {
       body: JSON.stringify({ dropboxId }),
+      headers: this.buildHeaders(),
       method: 'POST'
     });
 
     if (response.ok) {
-      const data = await response.json();
-      return data.map(
+      const { documents } = await response.json();
+      return documents.map(
         result =>
           new Document({
-            id: result.documentId,
-            filename: result.downloadUrl.split('/').reverse()[0],
-            description: result.description,
+            id: result.metadata.documentId,
+            filename: (result.downloadUrl || '').split('/').reverse()[0],
+            description: result.metadata.description,
             downloadUrl: result.downloadUrl
           })
       );

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -31,7 +31,22 @@ class EvidenceStoreGateway {
       };
     } else {
       console.log(response);
-      throw new Error('Call to Evidence Store failed.');
+      throw new Error('Call to Evidence Store failed');
+    }
+  }
+
+  async resolveDownloadUrl(downloadUrl) {
+    const response = await fetch(`${downloadUrl}?redirect=false`, {
+      method: 'GET',
+      headers: this.buildHeaders()
+    });
+
+    if (response.ok) {
+      const { downloadUrl } = await response.json();
+      return downloadUrl;
+    } else {
+      console.log(response);
+      throw new Error('Call to Evidence Store failed');
     }
   }
 
@@ -44,18 +59,24 @@ class EvidenceStoreGateway {
 
     if (response.ok) {
       const { documents } = await response.json();
+
+      console.log(
+        `Found ${documents.length} documents`,
+        JSON.stringify(documents)
+      );
+
       return documents.map(
         result =>
           new Document({
             id: result.metadata.documentId,
-            filename: (result.downloadUrl || '').split('/').reverse()[0],
+            filename: result.metadata.filename,
             description: result.metadata.description,
-            downloadUrl: result.downloadUrl
+            downloadUrl: `${this.baseUrl}/${result.metadata.documentId}/contents`
           })
       );
     } else {
       console.log(response);
-      throw new Error('Call to Evidence Store failed.');
+      throw new Error('Call to Evidence Store failed');
     }
   }
 }

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -1,0 +1,54 @@
+const nock = require('nock');
+const EvidenceStoreGateway = require('./EvidenceStoreGateway');
+
+describe('gateway/evidenceStore', () => {
+  let scope;
+  const gateway = new EvidenceStoreGateway({
+    baseUrl: 'http://localhost:5050'
+  });
+
+  const expectedDropboxId = 'ajs83jhdl';
+
+  beforeEach(() => {
+    scope = nock('http://localhost:5050')
+      .post('/metadata', { dropboxId: expectedDropboxId })
+      .reply(201, {
+        documentId: 'ajs873',
+        url: 'https://secure.upload.url',
+        fields: {
+          'X-Amz-Random-Header': 'value'
+        }
+      });
+  });
+
+  describe('createUploadUrl', () => {
+    it('calls Evidence Store API with the dropbox id', async () => {
+      await gateway.createUploadUrl(expectedDropboxId);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns correct url and fields', async () => {
+      const result = await gateway.createUploadUrl(expectedDropboxId);
+      expect(result.url).toStrictEqual('https://secure.upload.url');
+      expect(result.fields).toStrictEqual({ 'X-Amz-Random-Header': 'value' });
+    });
+
+    it('throws an error if API call fails', async () => {
+      const errorScope = nock('http://localhost:5050')
+        .post('/metadata', { dropboxId: '123456' })
+        .reply(500);
+
+      await expect(() => gateway.createUploadUrl('123456')).rejects.toThrow();
+      expect(errorScope.isDone()).toBe(true);
+    });
+
+    it('throws an error if API call times out', async () => {
+      const errorScope = nock('http://localhost:5050')
+        .post('/metadata', { dropboxId: '123456' })
+        .replyWithError({ code: 'ETIMEDOUT' });
+
+      await expect(() => gateway.createUploadUrl('123456')).rejects.toThrow();
+      expect(errorScope.isDone()).toBe(true);
+    });
+  });
+});

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -33,6 +33,11 @@ describe('gateway/evidenceStore', () => {
       expect(result.fields).toStrictEqual({ 'X-Amz-Random-Header': 'value' });
     });
 
+    it('returns the document id', async () => {
+      const result = await gateway.createUploadUrl(expectedDropboxId);
+      expect(result.documentId).toStrictEqual('ajs873');
+    });
+
     it('throws an error if API call fails', async () => {
       const errorScope = nock('http://localhost:5050')
         .post('/metadata', { dropboxId: '123456' })

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -66,14 +66,18 @@ describe('gateway/evidenceStore', () => {
       const expectedSignedUrl = `https://s3.amazonaws.com/${documentId}/${filename}`;
 
       nock('http://localhost:5050')
-        .post('/documents', { dropboxId: expectedDropboxId })
-        .reply(200, [
-          {
-            documentId,
-            description,
-            downloadUrl: expectedSignedUrl
-          }
-        ]);
+        .post('/search', { dropboxId: expectedDropboxId })
+        .reply(200, {
+          documents: [
+            {
+              metadata: {
+                documentId,
+                description
+              },
+              downloadUrl: expectedSignedUrl
+            }
+          ]
+        });
 
       const documents = await gateway.getByDropboxId(expectedDropboxId);
 

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -58,12 +58,23 @@ describe('gateway/evidenceStore', () => {
     });
   });
 
+  describe('deleteByDocumentId', () => {
+    it('requests that the document is deleted', async () => {
+      const scope = nock('http://localhost:5050')
+        .delete('/ab92js')
+        .reply(204);
+
+      await gateway.deleteByDocumentId('ab92js');
+      expect(scope.isDone()).toBe(true);
+    });
+  });
+
   describe('getByDropboxId', () => {
     it('returns a list of documents within a dropbox', async () => {
       const documentId = 'document-1';
       const filename = 'my-cat.jpg';
       const description = 'Photo of my cat';
-      const expectedSignedUrl = `https://s3.amazonaws.com/${documentId}/${filename}`;
+      const expectedSignedUrl = `http://localhost:5050/${documentId}/contents`;
 
       nock('http://localhost:5050')
         .post('/search', { dropboxId: expectedDropboxId })
@@ -72,7 +83,8 @@ describe('gateway/evidenceStore', () => {
             {
               metadata: {
                 documentId,
-                description
+                description,
+                filename
               },
               downloadUrl: expectedSignedUrl
             }

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -1,4 +1,5 @@
 const nock = require('nock');
+const { Document } = require('../../domain/dropbox');
 const EvidenceStoreGateway = require('./EvidenceStoreGateway');
 
 describe('gateway/evidenceStore', () => {
@@ -54,6 +55,40 @@ describe('gateway/evidenceStore', () => {
 
       await expect(() => gateway.createUploadUrl('123456')).rejects.toThrow();
       expect(errorScope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getByDropboxId', () => {
+    it('returns a list of documents within a dropbox', async () => {
+      const documentId = 'document-1';
+      const filename = 'my-cat.jpg';
+      const description = 'Photo of my cat';
+      const expectedSignedUrl = `https://s3.amazonaws.com/${documentId}/${filename}`;
+
+      nock('http://localhost:5050')
+        .post('/documents', { dropboxId: expectedDropboxId })
+        .reply(200, [
+          {
+            documentId,
+            description,
+            downloadUrl: expectedSignedUrl
+          }
+        ]);
+
+      const documents = await gateway.getByDropboxId(expectedDropboxId);
+
+      expect(documents.length).toBe(1);
+
+      const [document] = documents;
+      expect(document).toBeInstanceOf(Document);
+      expect(document).toStrictEqual(
+        expect.objectContaining({
+          id: documentId,
+          filename,
+          description,
+          downloadUrl: expectedSignedUrl
+        })
+      );
     });
   });
 });

--- a/lib/use-cases/DeleteDocument.js
+++ b/lib/use-cases/DeleteDocument.js
@@ -1,5 +1,5 @@
-module.exports = ({ gateways: { document: documents } }) => {
-  return async (dropboxId, documentId) => {
-    await documents.deleteFromDropbox(dropboxId, documentId);
+module.exports = ({ gateways: { evidenceStore } }) => {
+  return async documentId => {
+    await evidenceStore.deleteByDocumentId(documentId);
   };
 };

--- a/lib/use-cases/DeleteDocument.test.js
+++ b/lib/use-cases/DeleteDocument.test.js
@@ -1,8 +1,8 @@
 describe('use-case/delete document', () => {
   const options = {
     gateways: {
-      document: {
-        deleteFromDropbox: jest.fn(() => Promise.resolve())
+      evidenceStore: {
+        deleteByDocumentId: jest.fn(() => Promise.resolve())
       }
     }
   };
@@ -10,13 +10,11 @@ describe('use-case/delete document', () => {
   const deleteDocument = require('./DeleteDocument')(options);
 
   it('deletes the document from the dropbox', async () => {
-    const dropboxId = 'db123456';
     const documentId = 'doc98765';
-    await deleteDocument(dropboxId, documentId);
+    await deleteDocument(documentId);
 
-    expect(options.gateways.document.deleteFromDropbox).toHaveBeenCalledWith(
-      dropboxId,
-      documentId
-    );
+    expect(
+      options.gateways.evidenceStore.deleteByDocumentId
+    ).toHaveBeenCalledWith(documentId);
   });
 });

--- a/lib/use-cases/GetDropbox.js
+++ b/lib/use-cases/GetDropbox.js
@@ -1,10 +1,8 @@
-module.exports = ({
-  gateways: { dropbox: dropboxes, document: documents }
-}) => {
+module.exports = ({ gateways: { dropbox: dropboxes, evidenceStore } }) => {
   return async dropboxId => {
     const [dropbox, uploads] = await Promise.all([
       dropboxes.get(dropboxId),
-      documents.getByDropboxId(dropboxId)
+      evidenceStore.getByDropboxId(dropboxId)
     ]);
 
     if (!dropbox) {

--- a/lib/use-cases/GetDropbox.test.js
+++ b/lib/use-cases/GetDropbox.test.js
@@ -6,7 +6,7 @@ describe('use-case/get dropbox', () => {
       dropbox: {
         get: jest.fn()
       },
-      document: {
+      evidenceStore: {
         getByDropboxId: jest.fn(() => Promise.resolve([]))
       }
     }
@@ -49,7 +49,7 @@ describe('use-case/get dropbox', () => {
       });
 
       beforeEach(() => {
-        options.gateways.document.getByDropboxId.mockImplementation(() => {
+        options.gateways.evidenceStore.getByDropboxId.mockImplementation(() => {
           return Promise.resolve([expectedDocument]);
         });
       });
@@ -73,7 +73,7 @@ describe('use-case/get dropbox', () => {
 
     describe('without uploaded documents', () => {
       beforeEach(() => {
-        options.gateways.document.getByDropboxId.mockImplementation(() => {
+        options.gateways.evidenceStore.getByDropboxId.mockImplementation(() => {
           return Promise.resolve([]);
         });
       });

--- a/lib/use-cases/GetEvidenceStoreUrl.js
+++ b/lib/use-cases/GetEvidenceStoreUrl.js
@@ -1,0 +1,10 @@
+module.exports = ({ gateways: { evidenceStore } }) => {
+  return async dropboxId => {
+    const uploadOptions = await evidenceStore.createUploadUrl(dropboxId);
+    return {
+      documentId: uploadOptions.documentId,
+      url: uploadOptions.url,
+      fields: uploadOptions.fields
+    };
+  };
+};

--- a/lib/use-cases/GetEvidenceStoreUrl.test.js
+++ b/lib/use-cases/GetEvidenceStoreUrl.test.js
@@ -1,0 +1,31 @@
+describe('GetEvidenceStoreUrl', () => {
+  const expectedDocumentId = 'abst39';
+  const expectedUploadUrl = 'upload/url';
+  const options = {
+    gateways: {
+      document: {
+        createUploadUrl: jest.fn(() =>
+          Promise.resolve({
+            url: expectedUploadUrl,
+            fields: {},
+            documentId: expectedDocumentId
+          })
+        )
+      }
+    }
+  };
+
+  const getEvidenceStoreUrl = require('./GetEvidenceStoreUrl')(options);
+
+  it('creates a suitable upload url', async () => {
+    const dropboxId = 'db123456';
+    const { url, documentId } = await getEvidenceStoreUrl(dropboxId);
+
+    expect(options.gateways.document.createUploadUrl).toHaveBeenCalledWith(
+      dropboxId
+    );
+
+    expect(url).toBe(expectedUploadUrl);
+    expect(documentId).toStrictEqual(expectedDocumentId);
+  });
+});

--- a/lib/use-cases/GetEvidenceStoreUrl.test.js
+++ b/lib/use-cases/GetEvidenceStoreUrl.test.js
@@ -3,7 +3,7 @@ describe('GetEvidenceStoreUrl', () => {
   const expectedUploadUrl = 'upload/url';
   const options = {
     gateways: {
-      document: {
+      evidenceStore: {
         createUploadUrl: jest.fn(() =>
           Promise.resolve({
             url: expectedUploadUrl,
@@ -21,7 +21,7 @@ describe('GetEvidenceStoreUrl', () => {
     const dropboxId = 'db123456';
     const { url, documentId } = await getEvidenceStoreUrl(dropboxId);
 
-    expect(options.gateways.document.createUploadUrl).toHaveBeenCalledWith(
+    expect(options.gateways.evidenceStore.createUploadUrl).toHaveBeenCalledWith(
       dropboxId
     );
 

--- a/lib/use-cases/GetResolvedDownloadUrl.js
+++ b/lib/use-cases/GetResolvedDownloadUrl.js
@@ -1,0 +1,5 @@
+module.exports = ({ gateways: { evidenceStore } }) => {
+  return async downloadUrl => {
+    return await evidenceStore.resolveDownloadUrl(downloadUrl);
+  };
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4941,12 +4941,23 @@
       "dev": true
     },
     "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
       "requires": {
-        "iconv-lite": "~0.4.13"
+        "iconv-lite": "^0.6.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "dev": true,
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
       }
     },
     "encodr": {
@@ -7385,6 +7396,18 @@
       "requires": {
         "node-fetch": "^1.0.1",
         "whatwg-fetch": ">=0.10.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
+          }
+        }
       }
     },
     "isomorphic-ws": {
@@ -9909,6 +9932,12 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
+    "lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10552,6 +10581,35 @@
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
     },
+    "nock": {
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-13.0.2.tgz",
+      "integrity": "sha512-Wm8H22iT3UKPDf138tmgJ0NRfCLd9f2LByki9T2mGHnB66pEqvJh3gV/up1ZufZF24n7/pDYyLGybdqOzF3JIw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash.set": "^4.3.2",
+        "propagate": "^2.0.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "node-dir": {
       "version": "0.1.17",
       "resolved": "https://registry.npmjs.org/node-dir/-/node-dir-0.1.17.tgz",
@@ -10572,14 +10630,9 @@
       }
     },
     "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+      "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
     },
     "node-int64": {
       "version": "0.4.0",
@@ -11428,6 +11481,12 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.4"
       }
+    },
+    "propagate": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+      "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+      "dev": true
     },
     "proto-list": {
       "version": "1.2.4",
@@ -12330,6 +12389,16 @@
             "minimist": "^1.2.0",
             "prettyoutput": "^1.2.0",
             "strip-ansi": "^5.2.0"
+          }
+        },
+        "node-fetch": {
+          "version": "1.7.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+          "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+          "dev": true,
+          "requires": {
+            "encoding": "^0.1.11",
+            "is-stream": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "eslint-plugin-jest": "^23.8.2",
     "eslint-plugin-prettier": "^3.1.1",
     "jest": "^25.4.0",
+    "nock": "^13.0.2",
     "prettier": "^1.18.2",
     "serverless": "^1.67.0",
     "serverless-dynamodb-local": "^0.2.39",
@@ -53,6 +54,7 @@
     "jsonwebtoken": "^8.5.1",
     "lambda-api": "^0.10.5",
     "moment-timezone": "^0.5.28",
-    "nanoid": "^3.1.3"
+    "nanoid": "^3.1.3",
+    "node-fetch": "^2.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "debug": "node --inspect ./node_modules/serverless/bin/serverless offline -s dev",
     "dynamo": "sls dynamodb start -s dev",
     "dynamo-install": "sls dynamodb install",
-    "cypress-ui": "npx cypress open --env JWT_SECRET=my_secret",
+    "cypress-ui": "npx cypress open",
     "test-server": "sls offline start -s test",
     "test": "cypress run",
     "unit-test": "jest --verbose",

--- a/serverless.yml
+++ b/serverless.yml
@@ -31,6 +31,8 @@ provider:
     jwtsecret: ${ssm:/common/hackney-jwt-secret}
     CUSTOMER_TOKEN_SECRET: ${ssm:/common/customer-jwt-secret~true}
     stage: ${self:provider.stage}
+    EVIDENCE_STORE_URL: ${self:custom.evidenceStoreUrls.${self:provider.stage}}
+    EVIDENCE_STORE_TOKEN: ${ssm:/customer-document-uploads/evidence-store-token~true}
 
 custom:
   dynamodb:
@@ -50,6 +52,10 @@ custom:
     dev: http://localhost:3000
     test: http://localhost:3000
     production: https://uploads.hackney.gov.uk
+  evidenceStoreUrls:
+    dev: http://localhost:5050
+    test: https://staging-evidence-store.api.hackney.gov.uk
+    production: https://evidence-store.api.hackney.gov.uk
 
 plugins:
   - serverless-offline

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -36,7 +36,7 @@
       {{#each secureUploadFields}}
       <input type="hidden" name="{{@key}}" value="{{this}}" />
       {{/each}}
-      <input type="hidden" name="key" value="{{dropboxId}}/{{secureDocumentId}}/${filename}" />
+      <input type="hidden" name="key" value="{{secureDocumentId}}/${filename}" />
       <input type="hidden" name="X-Amz-Server-Side-Encryption" value="AES256" />
       <label for="x-amz-meta-description">File description</label>
       <input type="text" class="form-control" id="x-amz-meta-description" name="x-amz-meta-description"

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -133,7 +133,7 @@
         body: new FormData(form),
         mode: 'no-cors',
       }).then(function (data) {
-        window.location.reload();
+        setTimeout(function () { window.location.reload(); }, 2000);
       }).catch(function (m) {
         uploadButton.disabled = false;
         uploadButton.innerText = 'Upload Document';

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -19,8 +19,7 @@
             {{#if this.description }} - {{this.description}}{{/if }}
           </div>
           <div>
-            <form method="POST" action="/dropboxes/{{ ../dropboxId }}/files/{{ this.id }}"
-              onSubmit="javascript: return confirm('Are you sure you want to delete this document?');">
+            <form method="POST" class="delete-file" action="/dropboxes/{{ ../dropboxId }}/files/{{ this.id }}">
               <input type="hidden" name="_method" value="DELETE" />
               <button class="btn btn-danger">Delete</button>
             </form>
@@ -142,7 +141,36 @@
       return false;
     }
 
+    function doAsyncDelete(event) {
+      event.preventDefault();
+
+      if (!confirm('Are you sure you want to delete this document?')) {
+        return false;
+      }
+
+      var form = event.target;
+      var button = form.querySelector('button');
+      button.disabled = true;
+      button.innerText = 'Deleting...';
+
+      fetch(form.action, {
+        method: form.method,
+        body: new URLSearchParams(new FormData(form)),
+        mode: 'no-cors',
+      }).then(function (data) {
+        setTimeout(function () { window.location.reload(); }, 500);
+      }).catch(function (m) {
+        button.disabled = false;
+        button.innerText = 'Delete';
+      });
+
+      return false;
+    }
+
     document.querySelector('#upload').addEventListener('submit', doAsyncUpload);
+    document.querySelectorAll('form.delete-file').forEach(function (element) {
+      element.addEventListener('submit', doAsyncDelete);
+    });
   })();
 </script>
 {{> footer isStaff=false }}

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -31,7 +31,7 @@
     {{/each}}
   </ul>
   {{/if }}
-  <form action="{{ secureUploadUrl }}" method="POST" enctype="multipart/form-data">
+  <form id="upload" action="{{ secureUploadUrl }}" method="POST" enctype="multipart/form-data">
     <div class="form-group">
       {{#each secureUploadFields}}
       <input type="hidden" name="{{@key}}" value="{{this}}" />
@@ -119,4 +119,30 @@
   </script>
 </section>
 {{/if }}
+<script type="text/javascript">
+  (function () {
+    function doAsyncUpload(event) {
+      event.preventDefault();
+      var form = event.target;
+      var uploadButton = form.querySelector('#uploadFile');
+      uploadButton.disabled = true;
+      uploadButton.innerText = 'Uploading...';
+
+      fetch(form.action, {
+        method: form.method,
+        body: new FormData(form),
+        mode: 'no-cors',
+      }).then(function (data) {
+        window.location.reload();
+      }).catch(function (m) {
+        uploadButton.disabled = false;
+        uploadButton.innerText = 'Upload Document';
+      });
+
+      return false;
+    }
+
+    document.querySelector('#upload').addEventListener('submit', doAsyncUpload);
+  })();
+</script>
 {{> footer isStaff=false }}


### PR DESCRIPTION
**What**
Switches to using the Evidence Store API, rather than a local S3 bucket.

**Why**
So that we can prove the Evidence Store API in a real-world scenario, discover any issues with the API and have a single place within Hackney where all evidence documents are stored.

**Anything else?**
 - Adds a new configuration value to SSM named `/customer-document-uploads/evidence-store-token`. This is a JWT used to authenticate with the Evidence Store API as calls to document uploads are anonymous and therefore we cannot rely on the token from those requests to pass through.