### PR TITLE
Use existing empty document folder if one exists

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,7 +60,7 @@ jobs:
 
 workflows:
   version: 2
-  build-and-deploy-when-master:
+  build-and-deploy:
     jobs:
       - build
       - deploy:

--- a/lambda.js
+++ b/lambda.js
@@ -52,9 +52,6 @@ api.use(async (req, res, next) => {
 });
 
 api.get('/login', async (req, res) => {
-  if (authorize(req)) {
-    return res.redirect('/dropboxes');
-  }
   const html = templates.loginTemplate();
   return res.html(html);
 });

--- a/lambda.js
+++ b/lambda.js
@@ -52,8 +52,11 @@ api.use(async (req, res, next) => {
 });
 
 api.get('/login', async (req, res) => {
+  if (authorize(req)) {
+    return res.redirect('/dropboxes');
+  }
   const html = templates.loginTemplate();
-  res.html(html);
+  return res.html(html);
 });
 
 api.get('/logout', async (req, res) => {

--- a/lambda.test.js
+++ b/lambda.test.js
@@ -1,6 +1,5 @@
 jest.mock('./lib/Dependencies');
 const {
-  authorize,
   getDropbox,
   getEvidenceStoreUrl,
   getSession,
@@ -21,13 +20,6 @@ describe('handler routes', () => {
     it('shows the login page if not logged in', async () => {
       await handler(evt('GET', '/login'), {});
       expect(templates.loginTemplate).toHaveBeenCalled();
-    });
-
-    it('redirects to the dropboxes page if logged in', async () => {
-      authorize.mockImplementationOnce(() => true);
-      const res = await handler(evt('GET', '/login'));
-      expect(res.statusCode).toBe(302);
-      expect(res.headers.location).toBe('/dropboxes');
     });
   });
 

--- a/lambda.test.js
+++ b/lambda.test.js
@@ -1,0 +1,90 @@
+jest.mock('./lib/Dependencies');
+const {
+  authorize,
+  getDropbox,
+  getEvidenceStoreUrl,
+  getSession,
+  templates
+} = require('./lib/Dependencies');
+
+const evt = (method, path) => {
+  return {
+    httpMethod: method,
+    path
+  };
+};
+
+describe('handler routes', () => {
+  const handler = require('./lambda').handler;
+
+  describe('GET /login', () => {
+    it('shows the login page if not logged in', async () => {
+      await handler(evt('GET', '/login'), {});
+      expect(templates.loginTemplate).toHaveBeenCalled();
+    });
+
+    it('redirects to the dropboxes page if logged in', async () => {
+      authorize.mockImplementationOnce(() => true);
+      const res = await handler(evt('GET', '/login'));
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/dropboxes');
+    });
+  });
+
+  describe('GET /logout', () => {});
+
+  describe('GET /restart', () => {});
+
+  describe('GET /dropboxes', () => {});
+
+  describe('GET /dropboxes/new', () => {});
+
+  describe('GET /dropboxes/:id', () => {
+    it('shows the new dropbox template', async () => {
+      getSession.mockImplementationOnce(() => ({ dropboxId: '1' }));
+      getDropbox.mockImplementationOnce(() => true);
+      getEvidenceStoreUrl.mockImplementationOnce(() => ({
+        url: '',
+        fields: '',
+        documentId: ''
+      }));
+      await handler(evt('GET', '/dropboxes/1'));
+      expect(templates.createDropboxTemplate).toHaveBeenCalled();
+    });
+
+    it('redirects to new dropbox if no existing session', async () => {
+      getSession.mockImplementationOnce(() => false);
+      const res = await handler(evt('GET', '/dropboxes/1'));
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/dropboxes/new');
+    });
+
+    it('redirects to new dropbox if no existing dropbox', async () => {
+      getSession.mockImplementationOnce(() => ({ dropboxId: '1' }));
+      getDropbox.mockImplementationOnce(() => false);
+      const res = await handler(evt('GET', '/dropboxes/1'));
+      expect(res.statusCode).toBe(302);
+      expect(res.headers.location).toBe('/dropboxes/new');
+    });
+
+    it('shows the submitted dropbox page if a dropbox is submitted', async () => {
+      getSession.mockImplementationOnce(() => ({ dropboxId: '1' }));
+      getDropbox.mockImplementationOnce(() => ({ submitted: true }));
+      await handler(evt('GET', '/dropboxes/1'));
+      expect(templates.readonlyDropboxTemplate).toHaveBeenCalled();
+    });
+
+    it('shows the submitted dropbox page if a dropbox is submitted', async () => {
+      getSession.mockImplementationOnce(() => ({ dropboxId: '1' }));
+      getDropbox.mockImplementationOnce(() => ({ submitted: true }));
+      await handler(evt('GET', '/dropboxes/1'));
+      expect(templates.readonlyDropboxTemplate).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /dropboxes/:id/view', () => {});
+
+  describe('GET /dropboxes/:dropboxId/files/:fileId', () => {});
+
+  describe('POST /dropboxes/:dropboxId/files/:fileId', () => {});
+});

--- a/lib/gateways/document/EvidenceStoreGateway.js
+++ b/lib/gateways/document/EvidenceStoreGateway.js
@@ -36,7 +36,26 @@ class EvidenceStoreGateway {
       };
     } else {
       console.log(response);
-      throw new Error('Call to Evidence Store failed');
+      throw new Error('CreateUploadUrl: Call to Evidence Store failed');
+    }
+  }
+
+  async getUploadUrl(documentId) {
+    const response = await fetch(`${this.baseUrl}/${documentId}/upload-url`, {
+      headers: this.buildHeaders(),
+      method: 'GET'
+    });
+
+    if (response.ok) {
+      const data = await response.json();
+      return {
+        url: data.url,
+        fields: data.fields,
+        documentId: data.documentId
+      };
+    } else {
+      console.log(response);
+      throw new Error('GetUploadUrl: Call to Evidence Store failed');
     }
   }
 
@@ -51,7 +70,7 @@ class EvidenceStoreGateway {
       return downloadUrl;
     } else {
       console.log(response);
-      throw new Error('Call to Evidence Store failed');
+      throw new Error('ResolveDownloadUrl: Call to Evidence Store failed');
     }
   }
 
@@ -63,7 +82,7 @@ class EvidenceStoreGateway {
 
     if (!response.ok) {
       console.log(response);
-      throw new Error('Failed to delete document');
+      throw new Error('DeleteByDocumentId: Failed to delete document');
     }
   }
 
@@ -93,7 +112,7 @@ class EvidenceStoreGateway {
       );
     } else {
       console.log(response);
-      throw new Error('Call to Evidence Store failed');
+      throw new Error('GetByDropboxId: Call to Evidence Store failed');
     }
   }
 }

--- a/lib/gateways/document/EvidenceStoreGateway.test.js
+++ b/lib/gateways/document/EvidenceStoreGateway.test.js
@@ -3,26 +3,26 @@ const { Document } = require('../../domain/dropbox');
 const EvidenceStoreGateway = require('./EvidenceStoreGateway');
 
 describe('gateway/evidenceStore', () => {
-  let scope;
   const gateway = new EvidenceStoreGateway({
     baseUrl: 'http://localhost:5050'
   });
 
   const expectedDropboxId = 'ajs83jhdl';
 
-  beforeEach(() => {
-    scope = nock('http://localhost:5050')
-      .post('/metadata', { dropboxId: expectedDropboxId })
-      .reply(201, {
-        documentId: 'ajs873',
-        url: 'https://secure.upload.url',
-        fields: {
-          'X-Amz-Random-Header': 'value'
-        }
-      });
-  });
-
   describe('createUploadUrl', () => {
+    let scope;
+    beforeEach(() => {
+      scope = nock('http://localhost:5050')
+        .post('/metadata', { dropboxId: expectedDropboxId })
+        .reply(201, {
+          documentId: 'ajs873',
+          url: 'https://secure.upload.url',
+          fields: {
+            'X-Amz-Random-Header': 'value'
+          }
+        });
+    });
+
     it('calls Evidence Store API with the dropbox id', async () => {
       await gateway.createUploadUrl(expectedDropboxId);
       expect(scope.isDone()).toBe(true);
@@ -54,6 +54,56 @@ describe('gateway/evidenceStore', () => {
         .replyWithError({ code: 'ETIMEDOUT' });
 
       await expect(() => gateway.createUploadUrl('123456')).rejects.toThrow();
+      expect(errorScope.isDone()).toBe(true);
+    });
+  });
+
+  describe('getUploadUrl', () => {
+    const expectedDocumentId = 'xx123';
+    let scope;
+    beforeEach(() => {
+      scope = nock('http://localhost:5050')
+        .get('/xx123/upload-url')
+        .reply(200, {
+          documentId: 'xx123',
+          url: 'https://secure.upload.url',
+          fields: {
+            'X-Amz-Random-Header': 'value'
+          }
+        });
+    });
+
+    it('calls Evidence Store API with the dropbox id', async () => {
+      await gateway.getUploadUrl(expectedDocumentId);
+      expect(scope.isDone()).toBe(true);
+    });
+
+    it('returns correct url and fields', async () => {
+      const result = await gateway.getUploadUrl(expectedDocumentId);
+      expect(result.url).toStrictEqual('https://secure.upload.url');
+      expect(result.fields).toStrictEqual({ 'X-Amz-Random-Header': 'value' });
+    });
+
+    it('returns the document id', async () => {
+      const result = await gateway.getUploadUrl(expectedDocumentId);
+      expect(result.documentId).toStrictEqual(expectedDocumentId);
+    });
+
+    it('throws an error if API call fails', async () => {
+      const errorScope = nock('http://localhost:5050')
+        .get('/123456/upload-url')
+        .reply(500);
+
+      await expect(() => gateway.getUploadUrl('123456')).rejects.toThrow();
+      expect(errorScope.isDone()).toBe(true);
+    });
+
+    it('throws an error if API call times out', async () => {
+      const errorScope = nock('http://localhost:5050')
+        .get('/123456/upload-url')
+        .replyWithError({ code: 'ETIMEDOUT' });
+
+      await expect(() => gateway.getUploadUrl('123456')).rejects.toThrow();
       expect(errorScope.isDone()).toBe(true);
     });
   });

--- a/lib/use-cases/GetDropbox.js
+++ b/lib/use-cases/GetDropbox.js
@@ -1,6 +1,6 @@
 module.exports = ({ gateways: { dropbox: dropboxes, evidenceStore } }) => {
   return async dropboxId => {
-    const [dropbox, uploads] = await Promise.all([
+    const [dropbox, documents] = await Promise.all([
       dropboxes.get(dropboxId),
       evidenceStore.getByDropboxId(dropboxId)
     ]);
@@ -8,6 +8,8 @@ module.exports = ({ gateways: { dropbox: dropboxes, evidenceStore } }) => {
     if (!dropbox) {
       return null;
     }
+
+    const uploads = documents.filter(u => u.filename);
 
     return {
       ...dropbox,

--- a/lib/use-cases/GetDropbox.test.js
+++ b/lib/use-cases/GetDropbox.test.js
@@ -69,6 +69,19 @@ describe('use-case/get dropbox', () => {
         const dropbox = await getDropbox('abc123456');
         expect(dropbox.hasUploads).toBe(true);
       });
+
+      it('filters empty documents', async () => {
+        options.gateways.evidenceStore.getByDropboxId.mockImplementation(() => {
+          return Promise.resolve([
+            new Document({
+              id: 'def123456'
+            })
+          ]);
+        });
+        const dropbox = await getDropbox('abc123456');
+        console.log(dropbox);
+        expect(dropbox.hasUploads).toBe(false);
+      });
     });
 
     describe('without uploaded documents', () => {

--- a/lib/use-cases/GetEvidenceStoreUrl.js
+++ b/lib/use-cases/GetEvidenceStoreUrl.js
@@ -1,10 +1,18 @@
 module.exports = ({ gateways: { evidenceStore } }) => {
   return async dropboxId => {
-    const uploadOptions = await evidenceStore.createUploadUrl(dropboxId);
-    return {
-      documentId: uploadOptions.documentId,
-      url: uploadOptions.url,
-      fields: uploadOptions.fields
-    };
+    const documents = await evidenceStore.getByDropboxId(dropboxId);
+    const unusedDocuments = documents.filter(d => !d.filename);
+
+    if (unusedDocuments.length > 0) {
+      const { documentId, url, fields } = await evidenceStore.getUploadUrl(
+        unusedDocuments[0].id
+      );
+      return { documentId, url, fields };
+    } else {
+      const { documentId, url, fields } = await evidenceStore.createUploadUrl(
+        dropboxId
+      );
+      return { documentId, url, fields };
+    }
   };
 };

--- a/lib/use-cases/GetEvidenceStoreUrl.test.js
+++ b/lib/use-cases/GetEvidenceStoreUrl.test.js
@@ -10,22 +10,60 @@ describe('GetEvidenceStoreUrl', () => {
             fields: {},
             documentId: expectedDocumentId
           })
-        )
+        ),
+        getByDropboxId: jest.fn(),
+        getUploadUrl: jest.fn(() => ({
+          url: 'x',
+          fields: {},
+          documentId: 'x'
+        }))
       }
     }
   };
-
   const getEvidenceStoreUrl = require('./GetEvidenceStoreUrl')(options);
 
   it('creates a suitable upload url', async () => {
+    options.gateways.evidenceStore.getByDropboxId = jest.fn(() => {
+      return [
+        {
+          id: 'document-1',
+          description: 'Photo of my cat',
+          filename: 'my-cat.jpg',
+          downloadUrl: 'http://localhost:5050/document-1/contents'
+        }
+      ];
+    });
     const dropboxId = 'db123456';
+
     const { url, documentId } = await getEvidenceStoreUrl(dropboxId);
 
     expect(options.gateways.evidenceStore.createUploadUrl).toHaveBeenCalledWith(
       dropboxId
     );
-
     expect(url).toBe(expectedUploadUrl);
     expect(documentId).toStrictEqual(expectedDocumentId);
+  });
+
+  it('gets a url for an unused document if there is one', async () => {
+    options.gateways.evidenceStore.getByDropboxId = jest.fn(() => {
+      return [
+        {
+          id: 'document-1',
+          description: 'Photo of my cat',
+          filename: 'my-cat.jpg',
+          downloadUrl: 'http://localhost:5050/document-1/contents'
+        },
+        {
+          id: 'document-2'
+        }
+      ];
+    });
+
+    await getEvidenceStoreUrl('db123456');
+
+    expect(options.gateways.evidenceStore.getByDropboxId).toHaveBeenCalled();
+    expect(options.gateways.evidenceStore.getUploadUrl).toHaveBeenCalledWith(
+      'document-2'
+    );
   });
 });

--- a/serverless.yml
+++ b/serverless.yml
@@ -56,6 +56,7 @@ custom:
   evidenceStoreUrls:
     dev: http://localhost:5050
     test: https://staging-evidence-store.api.hackney.gov.uk
+    staging: https://staging-evidence-store.api.hackney.gov.uk
     production: https://evidence-store.api.hackney.gov.uk
 
 plugins:

--- a/templates/createDropbox.hbs
+++ b/templates/createDropbox.hbs
@@ -132,7 +132,7 @@
         body: new FormData(form),
         mode: 'no-cors',
       }).then(function (data) {
-        setTimeout(function () { window.location.reload(); }, 2000);
+        setTimeout(function () { window.location.reload(); }, 3000);
       }).catch(function (m) {
         uploadButton.disabled = false;
         uploadButton.innerText = 'Upload Document';


### PR DESCRIPTION
Rather that keeping on creating a new document folder for upload every time we refresh the page, we want to check if theres an empty one that we can use.

Added gateway function ```getUploadUrl``` and updated the ```GetEvidenceStoreUrl``` use case