### PR TITLE
Fix accessing of the resident name and add logging

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -95,7 +95,7 @@ api.get('/dropboxes/new', async (req, res) => {
 
   res.redirect(
     `/dropboxes/${dropbox.id}${
-    req.query.requestId ? `?requestId=${req.query.requestId}` : ''
+      req.query.requestId ? `?requestId=${req.query.requestId}` : ''
     }`
   );
 });
@@ -225,9 +225,12 @@ api.post('/dropboxes/:dropboxId', async (req, res) => {
   }
 
   const { dropboxId } = session;
+  console.log(`Saving dropbox: ${dropboxId}`);
   await saveDropbox(dropboxId, req.body);
 
+  console.log(`Sending notification for dropbox: ${dropboxId}`);
   await sendNotification({ dropboxId });
+
   return res.redirect(`/dropboxes/${dropboxId}`);
 });
 

--- a/lib/gateways/notification/govNotify.js
+++ b/lib/gateways/notification/govNotify.js
@@ -7,7 +7,7 @@ module.exports = ({ client, log, configuration }) => {
 
       const personalisation = {
         name: requestedBy,
-        residentName: dropbox.customerName,
+        residentName: dropbox.customer.name,
         description: dropbox.description,
         linkToDropbox: `${configuration.urlPrefix}/dropboxes/${dropbox.id}/view`
       };

--- a/lib/gateways/notification/govNotify.test.js
+++ b/lib/gateways/notification/govNotify.test.js
@@ -21,7 +21,7 @@ describe('gateway/govNotify', () => {
 
     it('calls gov notify API with the dropbox id', async () => {
       const dropbox = {
-        customerName: 'Bar',
+        customer: { name: 'Bar' },
         description: 'baz',
         id: '1'
       };

--- a/lib/use-cases/SendNotification.js
+++ b/lib/use-cases/SendNotification.js
@@ -13,11 +13,13 @@ module.exports = ({
       }
 
       if (documents[0].requestedBy && documents[0].requestedByEmail) {
-        return await notifyGateway.send(
+        const response = await notifyGateway.send(
           dropbox,
           documents[0].requestedBy,
           documents[0].requestedByEmail
         );
+        console.log('Notification sent: ');
+        console.log(response);
       }
     } catch (err) {
       console.log('Could not send email notification:' + err);


### PR DESCRIPTION
**What**
Fix accessing of the resident name and add logging

**Why**
Messaged weren't being sent because the name field was being accessed wrong.